### PR TITLE
Add RBAC role/rolebinding required by kuberesolver (spicedb dependency)

### DIFF
--- a/charts/spicedb/Chart.yaml
+++ b/charts/spicedb/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: spicedb
 description: A Helm chart to manage a Kubernetes based deployment of Authzed spicedb. For more information see https://github.com/authzed/spicedb.
 type: application
-version: 0.0.1
+version: 0.0.2
 appVersion: "v1.4.0"

--- a/charts/spicedb/templates/role.yaml
+++ b/charts/spicedb/templates/role.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.serviceAccount.create .Values.serviceAccount.createAndBindRole -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "spicedb.fullname" . }}-watchEndpoints
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+{{- end }}

--- a/charts/spicedb/templates/rolebinding.yaml
+++ b/charts/spicedb/templates/rolebinding.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.serviceAccount.create .Values.serviceAccount.createAndBindRole -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "spicedb.serviceAccountName" . }}-kuberesolver-access
+roleRef:
+  kind: Role
+  name: watchEndpoints
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ include "spicedb.serviceAccountName" . }}
+  namespace: {{ Release.Namespace }}
+{{- end }}

--- a/charts/spicedb/values.yaml
+++ b/charts/spicedb/values.yaml
@@ -68,6 +68,9 @@ fullnameOverride: ""
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
+  # Specifies whether a Role & RoleBinding should be created for this service account
+  # Ignored when `serviceAccount.create` is false
+  createAndBindRole: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.


### PR DESCRIPTION
Hello! 👋 

First off, cool project that I found through the grapevine! I hope you don't mind this unsolicited Pull Request...

Prior to adding this Role/RoleBinding myself, I was seeing this in the error logs:
```
2022/03/03 19:07:58 ERROR: kuberesolver: watching ended with error='invalid response code 403 for service zanzibar-spicedb in namespace zanzibar', will reconnect again
```

With performance implications and timeouts. I can keep my `kustomize` patch in place, but I figured I should check to see if this would be helpful to add into your chart directly.